### PR TITLE
-tm accepts all URIs not only those starting with 'http'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,8 @@ nb-configuration.xml
 nbactions.xml
 gc.log
 src/main/java/be/ugent/mmlab/rml/main/Main_*.java
+
+# Intellij IDEA
+
+.idea
+*.iml

--- a/src/main/java/be/ugent/mmlab/rml/config/RMLConfiguration.java
+++ b/src/main/java/be/ugent/mmlab/rml/config/RMLConfiguration.java
@@ -80,13 +80,13 @@ public class RMLConfiguration {
         if (parameters != null) {
             String[] exeTriplesMap = parameters.split(",");
             for (int i = 0; i < exeTriplesMap.length; i++) {
-                if(exeTriplesMap[i].startsWith("http"))
-                    continue;
-                if (baseIRI != null) {
-                   exeTriplesMap[i] = baseIRI + exeTriplesMap[i];
-                } else {
-                    File file = new File(map_doc);
-                    exeTriplesMap[i] = "file:" + file.getAbsolutePath() + "#" + exeTriplesMap[i];
+                if(!exeTriplesMap[i].matches("\\w+:(/?/?)[^\\s]+")) {
+                    if (baseIRI != null) {
+                        exeTriplesMap[i] = baseIRI + exeTriplesMap[i];
+                    } else {
+                        File file = new File(map_doc);
+                        exeTriplesMap[i] = "file:" + file.getAbsolutePath() + "#" + exeTriplesMap[i];
+                    }
                 }
             }
             return exeTriplesMap;


### PR DESCRIPTION
The `-tm` should accept all URI variances, not only those starting with `http` word. It is done by a regex matching.